### PR TITLE
fix: remove back-slashes in input's glob expression

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -70,7 +70,7 @@ export default function(options: Partial<Options> = {}): Plugin {
 			if (compileOptions.input.includes('*')) {
 				input = compileOptions.input
 			} else if (!compileOptions.input.match(/\.mjml/)) {
-				input = path.join(compileOptions.input, '**/*.mjml')
+				input = path.join(compileOptions.input, '**/*.mjml').replace(/\\/g, '/')
 			}
 
 			const files = await fg(input)


### PR DESCRIPTION
This PR should fix input glob pattern on Windows:
While preparing input path for compilation, the node's `path.join()` on windows returns path with back-slashes, this should be fine if `fast-glob` internally supports back-slashes in glob expression, but it doens't, see [fast-glob](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows) docs