### PR TITLE
feat: add support for mj-include

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -23,7 +23,10 @@ export function compileInput(input: string, options: CompileOptions) {
 	const content = fs.readFileSync(input, 'utf-8')
 
 	try {
-		const result = mjml(content, options.mjml)
+		const result = mjml(content, { 
+			filePath: input,
+			...options.mjml
+		})
 		const outputFile = input
 			.replace(options.input, options.output)
 			.replace('.mjml', options.extension)


### PR DESCRIPTION
Currently, a file path is not specified when compiling mjml files, so the filePath defaults to the base path of the vite config file. This causes issues when using mjml-include tags, which typically include relative file paths. This PR adds the filePath to the mjml config options so the compiler can include the correct paths.